### PR TITLE
Fix verbose output for referenced schemas

### DIFF
--- a/lib/dot/gen_validate.jst
+++ b/lib/dot/gen_validate.jst
@@ -24,10 +24,10 @@ var {{=it.funcName}} = (function() {
             $it.funcName = 'refVal' + i;
           }}
           {{= it.gen_validate($it) }}
-          refVal[{{=i}}] = refVal{{=i}};
         {{?? typeof r == 'object' }}
-          refVal[{{=i}}] = {{=JSON.stringify(i)}};
+          var refVal{{=i}} = {{=JSON.stringify(r)}};
         {{?}}
+        refVal[{{=i}}] = refVal{{=i}};
       {{?}}
     {{~}}
   {{?}}

--- a/spec/pack_validate.spec.js
+++ b/spec/pack_validate.spec.js
@@ -114,6 +114,14 @@ describe('module for a single validation function', function() {
     assert.strictEqual(packedValidate({foo: 1, bar: 2, baz: '3'}), false);
   });
 
+  it('should support enums in inlined referenced schemas', function() {
+    ajv.addSchema({ id: 'enum', type: 'string', enum: ['foo', 'bar'] });
+    var packedValidate = packCompile({ $ref: 'enum' });
+
+    assert.strictEqual(packedValidate('foo'), true);
+    assert.strictEqual(packedValidate('baz'), false);
+  });
+
   it('should support format keyword', function() {
     var schema = { type: 'string', format: 'date' };
     var packedValidate = packCompile(schema);

--- a/spec/pack_validate.spec.js
+++ b/spec/pack_validate.spec.js
@@ -60,6 +60,16 @@ describe('module for a single validation function', function() {
     assert.strictEqual(packedValidate(1), false);
   });
 
+  it('should support referenced schemas with verbose output', function() {
+    ajv = new Ajv({sourceCode: true, verbose: true});
+    ajv.addSchema({ id: 'str', type: 'string' });
+    var schema = { $ref: 'str' };
+    var packedValidate = packCompile(schema);
+
+    assert.strictEqual(packedValidate('foo'), true);
+    assert.strictEqual(packedValidate(1), false);
+  });
+
   it('should support referenced subschemas in referenced schemas', function() {
     var schema = {
       type: 'object',


### PR DESCRIPTION
This fixes an issue with verbose output, where an exception is thrown if there are errors on inlined referenced schemas.

In this case, the error objects look up the `refVal`s for the `schema` and `parentSchema` properties. However, these variables are not currently being set by `ajv-pack`, which causes a `ReferenceError: refVal1 is not defined`.

Given `{ "id": "str", "type": "string" }`, when we compile and pack `{ "$ref": "str" }` with verbose output, we get

```js
'use strict';
var validate = (function() {
  var refVal = [];
  refVal[1] = 1;
  return function validate(data, dataPath, parentData, parentDataProperty, rootData) {
    // ...
    if (typeof data !== "string") {
      validate.errors = [{
        // ...
        schema: refVal1.type,
        parentSchema: refVal1,
        data: data
      }];
      return false;
    }
    // ...
```

`refVal1` is not set (and `refVal[1]` is incorrectly set to `1`). This only happens with inlined refs because these are passed through as objects rather than functions, and therefore hit [the branch](https://github.com/epoberezkin/ajv-pack/blob/0.3.0/lib/dot/gen_validate.jst#L28-L30) that doesn't set the `refVal1` variable.

Also fixes #8.